### PR TITLE
Issue#1

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,13 @@ using the operating system's package manager.
 
 ### Installing OpenRadiant
 
-To create/update an OpenRadiant environment, ...
+To create/update an OpenRadiant environment, , invoke the `ansible/shard.yml`
+playbook.  Following is an example invocation.
+
+```bash
+cd ansible
+ansible-playbook -v env-basics.yml -e env_name==${env_name} -e envs=${envs} -e network_kind=flannel
+```
 
 To create/update an OpenRadiant shard, invoke the `ansible/shard.yml`
 playbook.  Following is an example invocation.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ using the operating system's package manager.
 
 ### Installing OpenRadiant
 
-To create/update an OpenRadiant environment, , invoke the `ansible/shard.yml`
+To create/update an OpenRadiant environment, invoke the `ansible/env-basics.yml`
 playbook.  Following is an example invocation.
 
 ```bash

--- a/ansible/load-vars-environment.yml
+++ b/ansible/load-vars-environment.yml
@@ -4,15 +4,6 @@
     - localhost
   gather_facts: no
   tasks:
-  - name: parse cluster name
-    delegate_to: localhost
-    shell: echo "{{cluster_name}}" | cut -d- -f1,2; echo "{{cluster_name}}" | cut -d- -f3-
-    register: nameres
-    changed_when: False
-
-  - set_fact:
-      env_name: "{{ nameres.stdout_lines[0] }}"
-
   - debug: msg="environment name is '{{env_name}}', envs are in '{{envs}}'"
 
   - name: import environment defaults

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -124,7 +124,7 @@ on the localhost.
 ```bash
 ( cd ansible; \
   ansible-playbook -v -i ../examples/envs/dev-vbox/radiant01.hosts env-basics.yml \
-      -e "envs=../examples/envs cluster_name=dev-vbox-radiant01 network_kind=bridge" )
+      -e "envs=../examples/envs env_name=dev-vbox network_kind=bridge" )
 ```
 
 Use Ansible on the installer machine to deploy an OpenRadiant shard on

--- a/examples/vagrant/Vagrantfile
+++ b/examples/vagrant/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
     end
   end
-  
+
   config.vm.define 'proxy' do |proxy|
     proxy.vm.network "private_network", ip: "192.168.10.#{VM_COUNT+2}"
     proxy.vm.hostname = "proxy"
@@ -92,7 +92,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       installer.vm.provision "shell", inline: "apt-get -qq update && apt-get -qq -y install python-pip build-essential libssl-dev libffi-dev python-dev && cd /home/vagrant/openradiant && pip install -r requirements.txt"
 
       if name == 'active-installer-tiny'
-        installer.vm.provision "shell", privileged: false, inline: "cd /home/vagrant/openradiant/ansible && ansible-playbook -v -i /home/vagrant/openradiant/examples/envs/dev-vbox/radiant01.hosts env-basics.yml -e envs=/home/vagrant/openradiant/examples/envs -e cluster_name=dev-vbox-radiant01 -e network_kind=bridge"
+        installer.vm.provision "shell", privileged: false, inline: "cd /home/vagrant/openradiant/ansible && ansible-playbook -v -i /home/vagrant/openradiant/examples/envs/dev-vbox/radiant01.hosts env-basics.yml -e envs=/home/vagrant/openradiant/examples/envs -e env_name=dev-vbox -e network_kind=bridge"
         installer.vm.provision "shell", privileged: false, inline: "cd /home/vagrant/openradiant/ansible && ansible-playbook -v -i /home/vagrant/openradiant/examples/envs/dev-vbox/radiant01.hosts shard.yml -e envs=/home/vagrant/openradiant/examples/envs -e cluster_name=dev-vbox-radiant01 -e network_kind=bridge"
       end
 


### PR DESCRIPTION
closes issue #1 calling env-basics.yml now takes env_name as a parameter, and load-vars-environment.yml no longer parses the cluster name. I also updated the README, tiny example vagrantfile, and documentation. 