### PR TITLE
Removed dead code wrt stackrc

### DIFF
--- a/ansible/roles/k8sm-master/tasks/main.yml
+++ b/ansible/roles/k8sm-master/tasks/main.yml
@@ -87,10 +87,6 @@
 - name: "Copy podmaster yaml file to {{ k8s_kubelet_manifests_dir }}"
   template: src=podmaster.yaml.tmpl dest={{ k8s_kubelet_manifests_dir }}/podmaster.yaml mode=0644
 
-- name: check if we have a kraken installed
-  stat: path=/root/stackrc
-  register: stackrc
-
 - name: "Copy scheduler yaml file to {{ k8s_podmaster_manifests_dir }}"
   template: src={{ k8s_scheduler_cn }}.yaml.tmpl dest={{ k8s_podmaster_manifests_dir }}/{{ k8s_scheduler_cn }}.yaml mode=0644
 

--- a/ansible/roles/k8sm-worker/tasks/main.yml
+++ b/ansible/roles/k8sm-worker/tasks/main.yml
@@ -60,11 +60,6 @@
   template: src={{ k8s_user_cn }}-kubeconfig.tmpl dest={{ k8s_etc_dir }}/{{ k8s_user_cn }}-kubeconfig
   when: not kubernetes_on_mesos_deploy|bool
 
-- name: Check if we have a kraken installed
-  stat: path=/root/stackrc
-  register: stackrc
-  when: not kubernetes_on_mesos_deploy|bool
-
 - name: Copy kubelet and kubectl from image to local (for bootstrapping)
   shell: "{{ item }} "
   with_items:


### PR DESCRIPTION
Removed tasks that check whether `/root/stackrc` exists on the managed
machine, because they produce a result that is not used.

Fixes #29