### PR TITLE
Modify approach to copy binaries out of docker to work with user namespaces

### DIFF
--- a/ansible/roles/k8sm-master/tasks/main.yml
+++ b/ansible/roles/k8sm-master/tasks/main.yml
@@ -96,10 +96,10 @@
 - name: "Copy kubelet and kubectl from image to local (for bootstrapping)"
   shell: "{{ item }} "
   with_items:
-    - docker create --name this_is_a_temporary_container_i_will_delete {{ kube_image }}
-    - docker cp this_is_a_temporary_container_i_will_delete:/opt/kubernetes/bin/kubelet /usr/local/bin/kubelet
-    - docker cp this_is_a_temporary_container_i_will_delete:/opt/kubernetes/bin/kubectl /usr/local/bin/kubectl
-    - docker rm this_is_a_temporary_container_i_will_delete
+    - docker run --rm -v /tmp:/tmp --entrypoint cp {{ kube_image }} /opt/kubernetes/bin/kubelet /tmp
+    - mv /tmp/kubelet /usr/local/bin
+    - docker run --rm -v /tmp:/tmp --entrypoint cp {{ kube_image }} /opt/kubernetes/bin/kubectl /tmp
+    - mv /tmp/kubectl /usr/local/bin
 
 - name: "Create kubelet upstart service"
   template: src=kubelet.conf.tmpl dest=/etc/init/kubelet.conf mode=0644

--- a/ansible/roles/k8sm-worker/tasks/main.yml
+++ b/ansible/roles/k8sm-worker/tasks/main.yml
@@ -63,9 +63,8 @@
 - name: Copy kubelet and kubectl from image to local (for bootstrapping)
   shell: "{{ item }} "
   with_items:
-    - docker create --name this_is_a_temporary_container_i_will_delete {{ kube_image }}
-    - docker cp this_is_a_temporary_container_i_will_delete:/opt/kubernetes/bin/kubelet /usr/local/bin/kubelet
-    - docker rm this_is_a_temporary_container_i_will_delete
+    - docker run --rm -v /tmp:/tmp --entrypoint cp {{ kube_image }} /opt/kubernetes/bin/kubelet /tmp 
+    - mv /tmp/kubelet /usr/local/bin
   when: not kubernetes_on_mesos_deploy|bool
 
 - name: Copy kube-proxy yaml file to {{ k8s_kubelet_manifests_dir }}


### PR DESCRIPTION
The 'docker cp" approach does not work with user namespace. With the
approach in this PR, the copy from docker to the host works with or
without user namespaces enabled in docker.
