### PR TITLE
Shard playbook to print ansible_version

### DIFF
--- a/ansible/shard.yml
+++ b/ansible/shard.yml
@@ -1,6 +1,10 @@
 ---
 - include: ./load-vars-cluster.yml
 
+- hosts: localhost
+  tasks:
+  - debug: var=ansible_version
+
 - hosts:
     - cluster-{{cluster_name}}
   tasks:


### PR DESCRIPTION
Added debug printing of `ansible_version` to the shard playbook.