### PR TITLE
Various fixes, mostly to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,12 @@ conventions for how environments and shards are organized and how they
 are described by files, are important parts of OpenRadiant's
 modularity.  This includes the inventory contracts that establish the
 orthogonality between (a) how machines are provisioned and (b) how
-software is installed on them.  See [the Ansible doc](docs/ansible.md)
-for details.
+software is installed on them.  This also includes the concept of
+networking plugins, the convention for where temporary and
+not-temporary files are kept on the installer machine(s), and the
+considerations for deploying in a context where external repositories
+can not be reached.  See [the Ansible doc](docs/ansible.md) for
+details.
 
 
 ### The installer machine

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -90,17 +90,29 @@ kubernetes_deploy: True
 kube_proxy_deploy: True
 
 # The operator needs to change the following if the hosts can not pull
-# from the indicated registries.
+# from the indicated registries, or if a different build of one of
+# these images is desired.
+
+# These two variables define the image and tag for the `hyperkube`
+# image, which is used for all the standard kubernetes components if
+# Mesos is not deployed.
 
 k8s_hyperkube_image: gcr.io/google_containers/hyperkube-amd64
+k8s_hyperkube_version: v1.3.5
+
+# This defines the image and tag (together in one variable; if no
+# colon is in the value then the usual Docker default --- "latest" ---
+# applies) to use for `km`, which is used for all the standard
+# kubernetes components if Mesos is deployed.
+
 kube_image: openradiant/km
+
 kube_podmaster_image: gcr.io/google_containers/podmaster:1.1
 kube_infra_image: gcr.io/google_containers/pause
 
 # There is no known reason for the operator to change any of the
 # following.
 
-k8s_hyperkube_version: v1.3.5
 k8s_etc_dir: /etc/kubernetes
 k8s_cert_dir: "{{k8s_etc_dir}}/cert"
 k8s_log_dir: /var/log/kubernetes
@@ -206,13 +218,6 @@ swarm_mesos_offertimeout: 10000m
 # Networking
 ################################################################
 
-# The name of the networking plugin to use.  Built-in plugins include:
-# "bridge" for plain old docker bridge networking, "flannel" for
-# Flannel with the host-gw backend.  See the networking plugin details
-# in the doc on Ansible structure.
-
-network_kind: bridge
-
 # The version of Flannel to use
 
 flannel_version: "0.5.5"
@@ -222,15 +227,31 @@ flannel_version: "0.5.5"
 # Infrastructure docker registry (used to deploy radiant components)
 ################################################################
 
+# The following two settings affect the way certain platform container
+# images are accessed.  The list is: remoteabac, etc, lb, mesos, and
+# ZooKeeper.  More/better doc is needed on what these mean.
+
 # possible values: v1 or v2
 infrastructure_docker_registry_type: v2
 # use 'always' with v2 and 'missing' with v1
 image_pull_type: always
 
+
 ###############################################################
 # Api-proxy variables
 ################################################################
 
+# The image name and tag to use for the proxy image.
+
 proxy_image_name: containercafe/api-proxy
+
+# A boolean that indicates whether the Ansible playbook that deploys
+# the proxy should first build the image for the proxy; the
+# alternative is to use a pre-built image of the configured name and
+# tag.
+
 build_proxy_image_locally: False
+
+# There is no known reason for anyone to change the following.
+
 proxy_context: dockerize

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -455,11 +455,18 @@ configures OpenRadiant to use those mirrors.
 
 For apt the answer is to configure an Ansible variable named `repos`
 that contains a list of records, one for each alternate apt repo to
-use.  Each record must contain a field named `key_url` having a value
-like `http://10.140.132.215:8082/Release.pgp`.  A record may also have
-a field named `validate_certs`.  These two fields are used as the
-values of the `url` and `validate_certs` (respectively) arguments of
-the `apt_key` module in Ansible.
+use.  Each record must contain a field that is named `repo` and has a
+value like `deb http://10.20.30.40:8082/ trusty main`.  A record may
+also have a field named `validate_certs`.  These two fields are used
+as the values of the corresponding arguments of the `apt_repository`
+module in Ansible.  A record may also have a field that is named
+`key_url` and has a value like `http://10.20.30.40:8082/Release.pgp`;
+in this case the `key_url` and `validate_certs` (if any) fields are
+used as the `url` and `validate_certs` (respectively) arguments of the
+`apt_key` module in Ansible.  Additionally, a record may also have a
+field that is named `key_package`; in this case Ansible's `apt` module
+is invoked with the `key_package` value passed through the `pkg`
+argument.
 
 For Docker the answer is to redefine the relevant Ansible variables
 that indicate the name and tag of the image to pull.  These variables

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -7,6 +7,7 @@
 * [Ansible variables](#ansible-variables)
 * [Networking plugins](#networking-plugins)
 * [Temporary and not-so-temporary file locations on the installer](#temporary-and-not-so-temporary-file-locations-on-the-installer)
+* [Considerations for deploying on machines that can not pull software from public sources](#considerations-for-deploying-on-machines-that-can-not-pull-software-from-public-sources)
 
 
 ## Overview
@@ -442,3 +443,24 @@ The platform operator is responsible for keeping the contents of
 `~/.openradiant/envs/{{ env_name }}/` persistent throughout the
 lifetime of the named environment and sharing it among all the
 installer machine(s) for that environment.
+
+
+## Considerations for deploying on machines that can not pull software from public sources
+
+There are two sorts of sources considered here: apt repositories and
+Docker registries (is it really true that there is no solution for
+pypi here?).  In both cases the platform operator must create a mirror
+from which the target machines _can_ pull.  The operator also needs to
+configures OpenRadiant to use those mirrors.
+
+For apt the answer is to configure an Ansible variable named `repos`
+that contains a list of records, one for each alternate apt repo to
+use.  Each record must contain a field named `key_url` having a value
+like `http://10.140.132.215:8082/Release.pgp`.  A record may also have
+a field named `validate_certs`.  These two fields are used as the
+values of the `url` and `validate_certs` (respectively) arguments of
+the `apt_key` module in Ansible.
+
+For Docker the answer is to redefine the relevant Ansible variables
+that indicate the name and tag of the image to pull.  These variables
+appear in `ansible/group_vars/all`.

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -66,6 +66,15 @@ ssh -i ~/.vagrant.d/insecure_private_key vagrant@192.168.10.2
 ```
 
 
+## FYI on using Docker in the deployed environment
+
+In this example's VMs, the `vagrant` user is not authorized to use
+docker.  If you `ssh` to one of these VMs and try to use raw Docker
+engine commands (i.e., without the settings explained
+[below](#exercise-the-shard-directly)) then you will need to `sudo`
+them.
+
+
 ## Prepare the installer machine
 
 To create an installer machine, you can either (1) use another Vagrant

--- a/examples/vagrant/Vagrantfile
+++ b/examples/vagrant/Vagrantfile
@@ -92,8 +92,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       installer.vm.provision "shell", inline: "apt-get -qq update && apt-get -qq -y install python-pip build-essential libssl-dev libffi-dev python-dev && cd /home/vagrant/openradiant && pip install -r requirements.txt"
 
       if name == 'active-installer-tiny'
-        installer.vm.provision "shell", privileged: false, inline: "cd /home/vagrant/openradiant/ansible && ansible-playbook -v -i /home/vagrant/openradiant/examples/envs/dev-vbox/radiant01.hosts env-basics.yml -e envs=/home/vagrant/openradiant/examples/envs -e env_name=dev-vbox -e network_kind=bridge"
-        installer.vm.provision "shell", privileged: false, inline: "cd /home/vagrant/openradiant/ansible && ansible-playbook -v -i /home/vagrant/openradiant/examples/envs/dev-vbox/radiant01.hosts shard.yml -e envs=/home/vagrant/openradiant/examples/envs -e cluster_name=dev-vbox-radiant01 -e network_kind=bridge"
+        installer.vm.provision "shell", privileged: false, inline: "cd /home/vagrant/openradiant/ansible && ansible-playbook -v -i /home/vagrant/openradiant/examples/envs/dev-vbox/radiant01.hosts env-basics.yml -e envs=/home/vagrant/openradiant/examples/envs -e env_name=dev-vbox"
+        installer.vm.provision "shell", privileged: false, inline: "cd /home/vagrant/openradiant/ansible && ansible-playbook -v -i /home/vagrant/openradiant/examples/envs/dev-vbox/radiant01.hosts shard.yml -e envs=/home/vagrant/openradiant/examples/envs -e cluster_name=dev-vbox-radiant01 -e network_kind=flannel"
       end
 
       installer.vm.provider "virtualbox" do |installer_node|


### PR DESCRIPTION
Added a section to the Ansible doc describing how to cope when the
target machines can not pull from public sources.

Added more descriptions into `ansible/group_vars/all`.

Removed `network_kind` from `ansible/group_vars/all` because
that variable must be supplied on the command line.

Explained that in the tiny example VMs, the vagrant user is not
authorized to use docker so `sudo` must be used.

Removed unneeded `network_kind` setting from the invocation
of the `env-basics.yml` playbook in the tiny example Vagrantfile.

Updated the invocation of the shard playbook in the tiny example
Vagrantfile to specify flannel rather than bridge as the networking
plugin to use.