### PR TITLE
Remove need for unused inventory groups

### DIFF
--- a/ansible/roles/lb/files/haproxyConfig.j2
+++ b/ansible/roles/lb/files/haproxyConfig.j2
@@ -80,7 +80,7 @@ backend back-rabac-secure
 #############################
 # Swarm
 #############################
-{% if lb_swarm %}
+{% if lb_swarm and swarm_deploy %}
 frontend lb-swarm
 	bind *:{{vip_swarm_master_port}}
 	mode http
@@ -98,7 +98,7 @@ backend swarm_backend
 #############################
 # Mesos
 #############################
-{% if lb_mesos %}
+{% if lb_mesos and mesos_deploy %}
 frontend lb-mesos
 	bind *:{{vip_mesos_master_port}}
 	mode http

--- a/ansible/shard.yml
+++ b/ansible/shard.yml
@@ -50,7 +50,7 @@
   tasks:
   - fail:
       msg: ha_deploy must be True when there are multiple hosts in the mesos_master-{{ cluster_name }} group in your Ansible inventory
-    when: groups['mesos_master-' ~ cluster_name]|length > 1 and not ha_deploy|bool
+    when: mesos_deploy and groups['mesos_master-' ~ cluster_name]|length > 1 and not ha_deploy|bool
 
 - hosts: localhost
   roles:
@@ -91,7 +91,7 @@
   become: yes
   roles:
   - lb
-  - { role: vip, when: "groups['mesos_master-' ~ cluster_name]|length > 1 or ha_deploy|bool" }
+  - { role: vip, when: "mesos_deploy and (groups['mesos_master-' ~ cluster_name]|length > 1 or ha_deploy|bool)" }
 
 - hosts: k8s_auth-{{cluster_name}}
   become: yes


### PR DESCRIPTION
when deploying with 

kube_deploy=yes
swarm_deploy=no
mesos_deploy=no

some pieces of code try to work on swarm and mesos configurations and fail because the hosts file does not contain any mesos/swarm configurations. 

updated the code to use the *_deploy flags before looking for the variables.