### PR TITLE
Documented gnu-tar workaround for issue 92

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Another way is to use Python's `easy_install` to install `pip`.
 Another way to get the `netaddr` module is to install `python-netaddr`
 using the operating system's package manager.
 
+If the installer machine is running MacOS 10 then it needs to have
+done `brew install gnu-tar`, for mysterious reasons.
+
 
 ### Installing OpenRadiant
 

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -102,14 +102,21 @@ See
 for the general story.  Following is one concrete realization of that
 story for this example.
 
-If you are running Ubuntu in your host, you may need to install the following
-python packages:
+If you are running Ubuntu on your installer, you may need to install
+the following python packages:
 
 ```bash
 sudo apt-get install python-pip python-dev
 ```
 
-Install ansible and its `netaddr` module:
+OTOH, if you are running MacOS 10 on your installer then you probably
+need to:
+
+```bash
+brew install gnu-tar
+```
+
+In any case, install ansible and its `netaddr` module:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
On MacOS, the Ansible `unarchive` module fails inexplicably on the
flannel-0.5.5 tar.gz --- unless you first `brew install gnu-tar`.
Documented this.