### PR TITLE
Corrected doc wrt env-basics and proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,14 @@ done `brew install gnu-tar`, for mysterious reasons.
 
 ### Installing OpenRadiant
 
-To create/update an OpenRadiant environment, invoke the `ansible/env-basics.yml`
-playbook.  Following is an example invocation.
+To create/update an OpenRadiant environment, invoke the
+`ansible/env-basics.yml` playbook.  This will create the certificates
+and keys that are common throughout the environment, and deploy the
+API proxy.  Following is an example invocation.
 
 ```bash
 cd ansible
-ansible-playbook -v env-basics.yml -e env_name==${env_name} -e envs=${envs}
+ansible-playbook -v env-basics.yml -e env_name==${env_kind}-${env_loc} -e envs=${envs}
 ```
 
 To create/update an OpenRadiant shard, invoke the `ansible/shard.yml`

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -136,8 +136,7 @@ pip install --upgrade ansible
 
 Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
-common throughout the environment.  Someday soon this will also deploy
-the API proxy.
+common throughout the environment, and deploy the API proxy.
 
 ```bash
 ( cd ansible; \


### PR DESCRIPTION
Updated docs to say that env-basics deploys the proxy.

Also updated the generic form of the env-basics invocation to show that an environment name has two parts connected with a dash.