### PR TITLE
kubectl exec, create secret generic, create secret docker-registry

### DIFF
--- a/proxy/src/handler/kube.go
+++ b/proxy/src/handler/kube.go
@@ -347,7 +347,6 @@ func kubeUpdateBody(r *http.Request, namespace string) (body []byte, err error) 
 	// annotations might not be provided in the yaml file:
 	if annot == nil {
 		annotm = make(map[string]interface{})
-		metam["annotations"] = annotm
 	} else {
 		// convert the existing annotation interface{} to map
 		annotm = annot.(map[string]interface{})


### PR DESCRIPTION
Addresses #117, #120, #121

- Rewritten the hijack loop to be more robust
- Fixed a crash due to an assignment to a potentially nil variable


Tested running the `tiny-example` without Mesos and Swarm