### PR TITLE
Merged hyperkube tag into image

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -93,19 +93,17 @@ kube_proxy_deploy: True
 # from the indicated registries, or if a different build of one of
 # these images is desired.
 
-# These two variables define the image and tag for the `hyperkube`
+# This defines the image (including tag) for the `hyperkube`
 # image, which is used for all the standard kubernetes components if
 # Mesos is not deployed.
 
-k8s_hyperkube_image: gcr.io/google_containers/hyperkube-amd64
-k8s_hyperkube_version: v1.3.5
+k8s_hyperkube_image: gcr.io/google_containers/hyperkube-amd64:v1.3.5
 
-# This defines the image and tag (together in one variable; if no
-# colon is in the value then the usual Docker default --- "latest" ---
-# applies) to use for `km`, which is used for all the standard
-# kubernetes components if Mesos is deployed.
+# This defines the image (including tag) to use for `km`, which is
+# used for all the standard kubernetes components if Mesos is
+# deployed.
 
-kube_image: openradiant/km
+kube_image: openradiant/km:v133_annotlab
 
 kube_podmaster_image: gcr.io/google_containers/podmaster:1.1
 kube_infra_image: gcr.io/google_containers/pause

--- a/ansible/roles/k8sm-master/templates/controller-manager.yaml.tmpl
+++ b/ansible/roles/k8sm-master/templates/controller-manager.yaml.tmpl
@@ -11,7 +11,7 @@ spec:
     {% if kubernetes_on_mesos_deploy|bool %}
     image: {{ kube_image }}
     {% else %}
-    image: {{k8s_hyperkube_image}}:{{k8s_hyperkube_version}}
+    image: {{k8s_hyperkube_image}}
     {% endif %}
     imagePullPolicy: Always
     command:

--- a/ansible/roles/k8sm-master/templates/scheduler.yaml.tmpl
+++ b/ansible/roles/k8sm-master/templates/scheduler.yaml.tmpl
@@ -11,7 +11,7 @@ spec:
   {% if kubernetes_on_mesos_deploy|bool %}
     image: {{ kube_image }}
   {% else %}
-    image: {{k8s_hyperkube_image}}:{{k8s_hyperkube_version}}
+    image: {{k8s_hyperkube_image}}
   {% endif %}
     imagePullPolicy: Always
     command:

--- a/ansible/roles/k8sm-worker/templates/kube-proxy.tmpl
+++ b/ansible/roles/k8sm-worker/templates/kube-proxy.tmpl
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: {{k8s_hyperkube_image}}:{{k8s_hyperkube_version}}
+    image: {{k8s_hyperkube_image}}
     command:
     - /hyperkube
     - proxy

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -304,16 +304,15 @@ Following are the most important of those variables.
   which of these three components are deployed.  The usual Ansible
   conventions for values for booleans apply.
 
-* `k8s_hyperkube_image`, `k8s_hyperkube_version`, `kube_image`: these
-  configure the kubernetes image to use; the first two are put
-  together as image name and tag when Mesos is *not* involved; the
-  third contains both image name and tag and is used when Mesos *is*
-  involved.
+* `k8s_hyperkube_image`, `kube_image`: these configure the kubernetes
+  image (including tag) to use; the first is used when Mesos is *not*
+  involved; the second is used when Mesos *is* involved.
 
-* `mesos_master_image`, `mesos_slave_image`: image name&tag to use for
-  Mesos on master and worker nodes (respectively).
+* `mesos_master_image`, `mesos_slave_image`: image name (including
+  tag) to use for Mesos on master and worker nodes (respectively).
 
-* `swarm_image`: image name and tag to use for the Swarm manager.
+* `swarm_image`: image name (including tag) to use for the Swarm
+  manager.
 
 * `ha_deploy`: controls whether a load balancer is deployed in front
   of the master components.  You pretty much want this when the master


### PR DESCRIPTION
Merged two ansible variables into one, containing the image reference
(including tag) to use for the Kubernetes image to use when Mesos is
*not* involved.  The separation was irregular and unhelpful.