### PR TITLE
Updated km to v1.3.6

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -28,9 +28,13 @@ Building is straightforward:
 ```
 cd openradiant/misc/dockerfiles/km
 docker login (with dockerhub creds)
-docker build -t openradiant/km .
-docker push openradiant/km
+docker build -t openradiant/km:$tag .
+docker push openradiant/km:$tag
 ```
+
+... where `$tag` is the value of `K8S_BRANCH` in the Dockerfile ---
+i.e., the git tag or branch of
+https://github.com/ibm-contribs/kubernetes.git that is being built.
 
 The selection of *what* to build is more complicated.  The choice is
 in the Dockerfile.  Documentation needed for the why behind that

--- a/misc/dockerfiles/km/Dockerfile
+++ b/misc/dockerfiles/km/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 ENV GO_VERSION 1.6.2
-ENV K8S_BRANCH v133_annotlab
+ENV K8S_BRANCH v1.3.6
 LABEL K8S_BRANCH=$K8S_BRANCH
 ENV GO_URL=https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz
 ENV GOPATH=/work


### PR DESCRIPTION
Skipping AnnotLabel because we are de-emphasizing SwarmV1 for now.

Updated doc about building to use explicit tags.