### PR TITLE
Updated k8s to v1.3.6 in group_vars/all

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -97,13 +97,13 @@ kube_proxy_deploy: True
 # image, which is used for all the standard kubernetes components if
 # Mesos is not deployed.
 
-k8s_hyperkube_image: gcr.io/google_containers/hyperkube-amd64:v1.3.5
+k8s_hyperkube_image: gcr.io/google_containers/hyperkube-amd64:v1.3.6
 
 # This defines the image (including tag) to use for `km`, which is
 # used for all the standard kubernetes components if Mesos is
 # deployed.
 
-kube_image: openradiant/km:v133_annotlab
+kube_image: openradiant/km:v1.3.6
 
 kube_podmaster_image: gcr.io/google_containers/podmaster:1.1
 kube_infra_image: gcr.io/google_containers/pause


### PR DESCRIPTION
This change moves both the with-Mesos and the sans-Mesos case to the most recent release in the 1.3 stream.  This changes the default to omit the support for kubernetes adding the container label used to identify tenants, which we do not need in the default because we are also removing SwarmV1 from the default configuration.