### PR TITLE
Clarify readme for tiny example

### DIFF
--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -97,7 +97,7 @@ most of the contents of the OpenRadiant repository in `~/openradiant`.
 
 ### Manually create installer
 
-If you have created the installer VM using [Create Installer VM](../tiny-example.md#create-installer-vm), you can skip this section.   To manually create the installer, see
+If you have created the installer VM using [Create Installer VM](#create-installer-vm), you can skip this section.   To manually create the installer, see
 [the general documentation of the installer machine](../README.md#the-installer-machine)
 for the general story.  Following is one concrete realization of that
 story for this example.

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -138,7 +138,7 @@ Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
 common throughout the environment, and deploy the API proxy.
 
-If you use the installer VM created from [Create Installer VM](#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](#fyi-on-ssh-to-vagrantvirtualbox-vms)
+If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -138,7 +138,7 @@ Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
 common throughout the environment, and deploy the API proxy.
 
-If you use the installer VM created from [Create Installer VM](../examples/tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../examples/tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
+If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -138,7 +138,7 @@ Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
 common throughout the environment, and deploy the API proxy.
 
-If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
+If you use the installer VM created from [Create Installer VM](#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](#fyi-on-ssh-to-vagrantvirtualbox-vms)
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -138,7 +138,7 @@ Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
 common throughout the environment, and deploy the API proxy.
 
-If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
+If you use the installer VM created from [Create Installer VM](../examples/tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../examples/tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -97,7 +97,7 @@ most of the contents of the OpenRadiant repository in `~/openradiant`.
 
 ### Manually create installer
 
-If you have created the installer VM using [Create Installer VM](../tiny-example.md#create-installer-vm), you can skip this section.   To manually create the installer, see
+If you have created the installer VM using [Create Installer VM](../examples/tiny-example.md#create-installer-vm), you can skip this section.   To manually create the installer, see
 [the general documentation of the installer machine](../README.md#the-installer-machine)
 for the general story.  Following is one concrete realization of that
 story for this example.
@@ -138,7 +138,7 @@ Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
 common throughout the environment, and deploy the API proxy.
 
-If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
+If you use the installer VM created from [Create Installer VM](../examples/tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../examples/tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -97,26 +97,19 @@ most of the contents of the OpenRadiant repository in `~/openradiant`.
 
 ### Manually create installer
 
-See
+If you have created the installer VM using [Create Installer VM](../tiny-example.md#create-installer-vm), you can skip this section.   To manually create the installer, see
 [the general documentation of the installer machine](../README.md#the-installer-machine)
 for the general story.  Following is one concrete realization of that
 story for this example.
 
-If you are running Ubuntu on your installer, you may need to install
-the following python packages:
+If you are running Ubuntu in your host, you may need to install the following
+python packages:
 
 ```bash
 sudo apt-get install python-pip python-dev
 ```
 
-OTOH, if you are running MacOS 10 on your installer then you probably
-need to:
-
-```bash
-brew install gnu-tar
-```
-
-In any case, install ansible and its `netaddr` module:
+Install ansible and its `netaddr` module:
 
 ```bash
 pip install -r requirements.txt
@@ -136,16 +129,24 @@ pip install --upgrade ansible
 
 Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
-common throughout the environment, and deploy the API proxy.
+common throughout the environment.  Someday soon this will also deploy
+the API proxy.   
+
+Use vagrant ssh to ssh into the installer machine:
+```bash
+vagrant ssh installer-tiny
+```
+
+Execute the following ansible scripts as the vagrant user:
 
 ```bash
 ( cd ansible; \
   ansible-playbook -v -i ../examples/envs/dev-vbox/radiant01.hosts env-basics.yml \
-      -e "envs=../examples/envs env_name=dev-vbox" )
+      -e "envs=../examples/envs env_name=dev-vbox cluster_name=dev-vbox-radiant01" )
 ```
 
 Use Ansible on the installer machine to deploy an OpenRadiant shard on
-the target machines.
+the target machines, using the vagrant user.
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -102,8 +102,8 @@ If you have created the installer VM using [Create Installer VM](../tiny-example
 for the general story.  Following is one concrete realization of that
 story for this example.
 
-If you are running Ubuntu in your host, you may need to install the following
-python packages:
+If you are running Ubuntu on your installer, you may need to install
+the following python packages:
 
 ```bash
 sudo apt-get install python-pip python-dev
@@ -138,21 +138,17 @@ Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
 common throughout the environment, and deploy the API proxy.
 
-If installer VM is used, use vagrant ssh to ssh into the installer machine:
+If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use vagrant ssh to ssh into the installer VM and execute the Ansible scripts as the *vagrant* user:
 ```bash
 vagrant ssh installer-tiny
 ```
 
-If installer VM is used, execute the following ansible scripts as the vagrant user:
-
 ```bash
 ( cd ansible; \
   ansible-playbook -v -i ../examples/envs/dev-vbox/radiant01.hosts env-basics.yml \
-      -e "envs=../examples/envs env_name=dev-vbox cluster_name=dev-vbox-radiant01" )
+      -e "envs=../examples/envs env_name=dev-vbox" )
 ```
 
-Use Ansible on the installer machine to deploy an OpenRadiant shard on
-the target machines.
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -16,7 +16,7 @@ at least Vagrant 1.8.4 and VirtualBox 5.0.24.
 Checkout this project:
 
 ```bash
-git clone git@github.ibm.com:alchemy-containers/openradiant.git
+git clone --recursive https://github.com/containercafe/containercafe.git
 cd openradiant
 ```
 
@@ -97,7 +97,7 @@ most of the contents of the OpenRadiant repository in `~/openradiant`.
 
 ### Manually create installer
 
-If you have created the installer VM using [Create Installer VM](#create-installer-vm), you can skip this section.   To manually create the installer, see
+If you have created the installer VM using [Create Installer VM](../tiny-example.md#create-installer-vm), you can skip this section.   To manually create the installer, see
 [the general documentation of the installer machine](../README.md#the-installer-machine)
 for the general story.  Following is one concrete realization of that
 story for this example.
@@ -109,7 +109,14 @@ python packages:
 sudo apt-get install python-pip python-dev
 ```
 
-Install ansible and its `netaddr` module:
+OTOH, if you are running MacOS 10 on your installer then you probably
+need to:
+
+```bash
+brew install gnu-tar
+```
+
+In any case, install ansible and its `netaddr` module:
 
 ```bash
 pip install -r requirements.txt
@@ -129,15 +136,14 @@ pip install --upgrade ansible
 
 Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
-common throughout the environment.  Someday soon this will also deploy
-the API proxy.   
+common throughout the environment, and deploy the API proxy.
 
-Use vagrant ssh to ssh into the installer machine:
+If installer VM is used, use vagrant ssh to ssh into the installer machine:
 ```bash
 vagrant ssh installer-tiny
 ```
 
-Execute the following ansible scripts as the vagrant user:
+If installer VM is used, execute the following ansible scripts as the vagrant user:
 
 ```bash
 ( cd ansible; \
@@ -146,7 +152,7 @@ Execute the following ansible scripts as the vagrant user:
 ```
 
 Use Ansible on the installer machine to deploy an OpenRadiant shard on
-the target machines, using the vagrant user.
+the target machines.
 
 ```bash
 ( cd ansible; \

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -138,10 +138,7 @@ Use Ansible on the installer machine to begin the process of deploying
 an environment.  This will create the certificates and keys that are
 common throughout the environment, and deploy the API proxy.
 
-If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use vagrant ssh to ssh into the installer VM and execute the Ansible scripts as the *vagrant* user:
-```bash
-vagrant ssh installer-tiny
-```
+If you use the installer VM created from [Create Installer VM](../tiny-example.md#create-installer-vm) as the installer machine, use *vagrant ssh* to SSH into the installer VM and execute the Ansible scripts as the *vagrant* user, as described in [FYI on SSH to Vagrant/VirtualBox VMs](../tiny-example.md#fyi-on-ssh-to-vagrantvirtualbox-vms)
 
 ```bash
 ( cd ansible; \
@@ -149,6 +146,8 @@ vagrant ssh installer-tiny
       -e "envs=../examples/envs env_name=dev-vbox" )
 ```
 
+Use Ansible on the installer machine to deploy an OpenRadiant shard
+on the target machines.
 
 ```bash
 ( cd ansible; \


### PR DESCRIPTION
I ran into a few issues when trying the tiny example with kubernetes module only today.
1) The doc was not clear as to tiny installer vm vs creating your own installer env.
2) i assumed it was using root user to run Ansible scripts, which caused not able to SSH into the VMs issue.