### PR TITLE
Updated git clone commands to cite current repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The controller machine must have git installed.
 Checkout this project along with all its submodules:
 
 ```bash
-git clone --recursive git@github.ibm.com:alchemy-containers/openradiant.git
+git clone --recursive https://github.com/containercafe/containercafe.git
 cd openradiant
 ```
 

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -16,7 +16,7 @@ at least Vagrant 1.8.4 and VirtualBox 5.0.24.
 Checkout this project:
 
 ```bash
-git clone git@github.ibm.com:alchemy-containers/openradiant.git
+git clone --recursive https://github.com/containercafe/containercafe.git
 cd openradiant
 ```
 


### PR DESCRIPTION
Say to clone containercafe rather than openradiant.