### PR TITLE
Turn swarm_deploy off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 OpenRadiant is a modular platform for enterprise container-native
-devops. OpenRadiant supports Kubernetes, and will eventually support
-and docker APIs on the same infrastructure.  OpenRadiant supports
-multi-tenancy and sharding.  The OpenRadiant platform can be extended
-by additional componentry, such as: support for using Mesos (including
-making Kubernetes act as a Mesos framework), support for using a
-CloudFoundry installation as the source of identities, support for
-using Neutron tenant networks to isolate OpenRadiant tenants in the
-network.
+devops. OpenRadiant supports Kubernetes, and will eventually also
+support the docker APIs on the same infrastructure.  OpenRadiant
+supports multi-tenancy and sharding.  The OpenRadiant platform can be
+extended by additional componentry, such as: support for using Mesos
+(including making Kubernetes act as a Mesos framework), support for
+using a CloudFoundry installation as the source of identities, support
+for using Neutron tenant networks to isolate OpenRadiant tenants in
+the network.
 
 Features of the OpenRadiant platform include:
 * Kubernetes
@@ -55,16 +55,14 @@ container-native devops service.
 One operating instantiation of the full platform is called an
 environment, and it contains one or more shards that operate
 independently of each other.  Each shard provides an independent
-installation of Kubernetes, and with extension additional platforms
-such as Mesos and/or Swarm.  There is an outer control plane with a
-proxy API server that implements the Kubernetes (and eventually
+installation of Kubernetes, and --- via extension --- additional
+platforms such as Mesos and/or Swarm.  There is an outer control plane
+with a proxy API server that implements the Kubernetes (and eventually
 Docker/SwarmV1) APIs --- with appropriate restrictions and extensions
 --- by appropriately transforming each RPC and dispatching it to the
 appropriate shard.
 
-You can subset OpenRadiant so that it creates just one shard.  You can
-subset OpenRadiant to omit API proxy if you are not interested in
-multi-sharding nor the conveniences it supplies for multi-tenancy.
+You can operate OpenRadiant with just one shard.
 
 In a shard there are worker nodes and master nodes.  The Kubernetes
 (and eventually Swarm) workload is dispatched to the worker nodes.

--- a/README.md
+++ b/README.md
@@ -3,23 +3,31 @@
 [![Travis Build Status](https://travis-ci.org/containercafe/containercafe.svg?branch=master)](https://travis-ci.org/containercafe/containercafe)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-OpenRadiant is a modular platform for enterprise container-native devops. OpenRadiant supports kubernetes and docker APIs on the same infrastructure in a multi-tenant setting. It provides the ability to customize your deployment options in order to select the components to deploy from among Kubernetes, Mesos, and Swarm. Currently it supports Flannel for networking. Soon other networking options will be available to select from.
+OpenRadiant is a modular platform for enterprise container-native
+devops. OpenRadiant supports Kubernetes, and will eventually support
+and docker APIs on the same infrastructure.  OpenRadiant supports
+multi-tenancy and sharding.  The OpenRadiant platform can be extended
+by additional componentry, such as: support for using Mesos (including
+making Kubernetes act as a Mesos framework), support for using a
+CloudFoundry installation as the source of identities, support for
+using Neutron tenant networks to isolate OpenRadiant tenants in the
+network.
 
 Features of the OpenRadiant platform include:
 * Kubernetes
-* Swarm (original, not "swarm mode" introduced in Docker 1.12)
-* Mesos
+* Eventually Swarm (original, not "swarm mode" introduced in Docker 1.12)
 * Multi-tenancy - with or without Bring-Your-Own-IPv4
 * Multi-sharding
 * HA control plane in each shard
 * Ansible-based create/update/destroy tooling
-* Support for a variety of sources of authentication
+* Openness to a variety of sources of authentication
 * Control plane secured by TLS
-* Support for a variety of Software-Defined-Network technologies
+* Openness to support for a variety of Software-Defined-Network technologies
 * Live container crawling
 
-OpenRadiant is a work in progress.  The above features are not yet
-available in all combinations.
+OpenRadiant is a work in progress, as a collaboration between a
+central OpenRadiant team and other teams that use it to build more
+specific and capable platforms.
 
 * [Architecture Overview](#architecture-overview)
 * [Tiny Example](examples/tiny-example.md)
@@ -40,28 +48,30 @@ available in all combinations.
 
 ### Architecture Overview
 
-OpenRadiant is software that you can subset and/or extend to produce
-software that you use to operate an enterprise container-native
-devops service.
+OpenRadiant is software that you can use, or extend to produce more
+capable software that you use, to operate an enterprise
+container-native devops service.
 
 One operating instantiation of the full platform is called an
 environment, and it contains one or more shards that operate
-independently of each other.  Each shard provides Kubernetes, Swarm,
-and/or Mesos service --- you can pick the subset you want, subject to
-reasonableness constraints.  There is an outer control plane with a
-proxy API server that implements the Kubernetes and Swarm APIs ---
-with appropriate restrictions and extensions --- by appropriately
-transforming each RPC and dispatching it to the appropriate shard.
+independently of each other.  Each shard provides an independent
+installation of Kubernetes, and with extension additional platforms
+such as Mesos and/or Swarm.  There is an outer control plane with a
+proxy API server that implements the Kubernetes (and eventually
+Docker/SwarmV1) APIs --- with appropriate restrictions and extensions
+--- by appropriately transforming each RPC and dispatching it to the
+appropriate shard.
 
 You can subset OpenRadiant so that it creates just one shard.  You can
 subset OpenRadiant to omit API proxy if you are not interested in
 multi-sharding nor the conveniences it supplies for multi-tenancy.
 
-In a shard there are worker nodes and control plane nodes.  The
-Kubernetes and Swarm workload is dispatched to the worker nodes.  The
-control plane nodes run the Kubernetes, Swarm, and/or Mesos control
-planes in an HA configuration.  We use Mesos to coordinate resource
-allocation decisions between Kubernetes and Swarm.
+In a shard there are worker nodes and master nodes.  The Kubernetes
+(and eventually Swarm) workload is dispatched to the worker nodes.
+The master nodes run the Kubernetes, eventually Swarm, and any
+extension's master components in an HA configuration.  We are working
+on a better solution than Mesos to coordinate resource allocation
+decisions between Kubernetes and Swarm.
 
 OpenRadiant includes Ansible-based installation technology to
 instantiate an OpenRadiant environment.  An installer machine acts as
@@ -69,9 +79,9 @@ Ansible controller to install OpenRadiant in a target environment.
 The installation is parameterized by some Ansible variables files that
 describe the desired target environment.
 
-OpenRadiant deploys Kubernetes, Swarm, and Mesos in containers.  You
-can choose whatever version of each that you want.  Your configure
-your choice of images and tags.  See the doc about
+OpenRadiant deploys Kubernetes in containers.  You can choose whatever
+version you want.  Your configure your choice of image (including
+tag).  See the doc about
 [the relevant configuration variables](docs/ansible.md#primary-shard-variables-that-have-defaults)
 and
 [where to put your settings for those variables](docs/ansible.md#additional-files-for-setting-ansible-variable-values).

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -41,7 +41,7 @@ ca_srl: ca.srl
 ha_deploy: True
 
 # The following variables are details of how the VIP is used.  There
-# is no known reason to vary any of them.
+# is no reason for the operator to change any of them.
 
 vip_k8s_apiserver_ip: "{{master_vip}}"
 vip_k8s_apiserver_port: 443
@@ -64,7 +64,7 @@ vip_swarm_master_port: 2375
 
 # HAProxy is always between master component clients and servers.  The
 # following variables control details of its configuration.  There is
-# no known reason to vary any of them.
+# no reason for the operator to change any of them.
 
 haproxy_image: haproxy:1.5
 haproxy_stats_port: 9000
@@ -108,8 +108,7 @@ kube_image: openradiant/km:v1.3.6
 kube_podmaster_image: gcr.io/google_containers/podmaster:1.1
 kube_infra_image: gcr.io/google_containers/pause
 
-# There is no known reason for the operator to change any of the
-# following.
+# There is no reason for the operator to change any of the following.
 
 k8s_etc_dir: /etc/kubernetes
 k8s_cert_dir: "{{k8s_etc_dir}}/cert"
@@ -174,8 +173,14 @@ zookeeper_port: 2181
 
 mesos_deploy: True
 
+# The following variables identify the image to use for the Mesos
+# master and worker components.
+
 mesos_master_image: mesosphere/mesos-master:1.0.0-rc2
 mesos_slave_image: mesosphere/mesos-slave:1.0.0-rc2
+
+# There is no reason for the operator to change any of the following.
+
 mesos_master_port: 5050
 mesos_slave_port: 5050
 use_mesos_roles: true
@@ -200,9 +205,16 @@ docker_engine_port: 2375
 
 # A boolean controlling whether the SwarmV1 master is deployed.
 
-swarm_deploy: True
+swarm_deploy: False
+
+# The Swarm manager is run in a Docker container, and this variable
+# identifies the image (with the usual default if tag is not
+# specified) to use.
 
 swarm_image: openradiant/swarm
+
+# There is no reason for the operator to change any of the following.
+
 swarm_manager_host_port: 4375
 swarm_manager_port: 4375
 swarm_manager_mesos_host_port: 3376
@@ -250,6 +262,6 @@ proxy_image_name: containercafe/api-proxy
 
 build_proxy_image_locally: False
 
-# There is no known reason for anyone to change the following.
+# There is no reason for the operator to change the following.
 
 proxy_context: dockerize

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,9 +36,7 @@ keeps track of the credentials needed to do so.
 OpenRadiant currently includes one authentication plugin, which keeps
 its data in files.  This is a very early point-in-time statement.
 
-You can subset OpenRadiant so that it creates just one shard.  You can
-subset OpenRadiant to omit API proxy if you are not interested in
-multi-sharding nor the conveniences it supplies for multi-tenancy.
+You can operate OpenRadiant with just one shard.
 
 In a shard there are worker nodes and master nodes.  The Kubernetes
 (and eventually Swarm workload) is run on the worker nodes.  The

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-OpenRadiant is software that you can subset and/or extend to produce
-software that you use to operate an enterprise container-native devops
-service.
+OpenRadiant is software that you can use, or extend to produce more
+capable software that you use, to operate an enterprise
+container-native devops service.
 
 One operating instantiation of the full platform is called an
 environment, and it contains one or more shards that operate
@@ -16,19 +16,11 @@ to a limited degree; OpenRadiant is not engineered for a large number
 of shards.  OpenRadiant includes an API proxy that proxies each
 request to the appropriate shard.
 
-Each shard provides Kubernetes, Swarm (V1, not the "swarm mode"
-introduced in Docker 1.12), and/or Mesos service.  The service
-operator can pick the subset she wants, subject to constraints.
-Currently SwarmV1 is available only with Mesos; that restriction could
-easily be lifted.  Mesos is needed to make Kubernetes and SwarmV1 work
-together nicely; if using only Kubernetes then Mesos is not needed.
-Mesos does not require Kubernetes nor Swarm, there are other Mesos
-frameworks that the service operator could deploy on her own.  The API
-proxy currently proxies only Kubernetes and SwarmV1 requests.  There
-are currently some issues that arise when using Mesos, such as the
-following.
-
-* [Empty ServiceAccount volumes when using Mesos](https://github.com/kubernetes/kubernetes/issues/31062)
+Each shard provides Kubernetes, eventually Swarm (V1, not the "swarm
+mode" introduced in Docker 1.12), and any platforms added by
+extensions.  The operator adds extensions by deploying them in a shard
+after the OpenRadiant installer does its work.  The API proxy
+currently proxies only Kubernetes and SwarmV1 requests.
 
 The API proxy has two main jobs: multi-sharding and multi-tenancy.
 The API proxy implements the Kubernetes and Swarm APIs --- with
@@ -48,11 +40,12 @@ You can subset OpenRadiant so that it creates just one shard.  You can
 subset OpenRadiant to omit API proxy if you are not interested in
 multi-sharding nor the conveniences it supplies for multi-tenancy.
 
-In a shard there are worker nodes and control plane nodes.  The
-Kubernetes and Swarm workload is run on the worker nodes.  The control
-plane nodes run the Kubernetes, Swarm, and/or Mesos control planes in
-an HA configuration.  We use Mesos to coordinate resource allocation
-decisions between Kubernetes and Swarm.  See
+In a shard there are worker nodes and master nodes.  The Kubernetes
+(and eventually Swarm workload) is run on the worker nodes.  The
+master nodes run the Kubernetes, eventually Swarm, and any extension's
+master components in an HA configuration.  We are working on a better
+solution than Mesos to coordinate resource allocation decisions
+between Kubernetes and Swarm.  See
 [a picture of a shard](media/DeployedShard.svg) for a picture of a
 shard with Kubernetes, SwarmV1, and Mesos.
 
@@ -76,12 +69,12 @@ Ansible controller to install OpenRadiant in a target environment.
 The installation is parameterized by some Ansible variables files that
 describe the desired target environment.
 
-OpenRadiant deploys Kubernetes, Swarm, and Mesos in containers.  You
-can choose whatever version of each that you want.  Your configure
-your choice of images and tags.  See the doc about
-[the relevant configuration variables](#docs/ansible.md#primary-shard-variables-that-have-defaults)
+OpenRadiant deploys Kubernetes in containers.  You can choose whatever
+version you want.  Your configure your choice of image (including
+tag).  See the doc about
+[the relevant configuration variables](docs/ansible.md#primary-shard-variables-that-have-defaults)
 and
-[where to put your settings for those variables](docs/ansible.md#additional-files-for-setting-Ansible-variable-values).
+[where to put your settings for those variables](docs/ansible.md#additional-files-for-setting-ansible-variable-values).
 
 The Ansible playbooks strive to meet the Ansible ideal of achieving a
 prescribed desired state, and can thus be used to update as well as

--- a/examples/tiny-example.md
+++ b/examples/tiny-example.md
@@ -2,11 +2,8 @@
 
 This produces a very simple demonstration shard of two VirtualBox VMs,
 one master and one worker, plus another VM for the proxy.  The shard
-has Mesos installed, and Kubernetes and Swarm playing nicely together
-thanks to Mesos.  The networking is Docker bridge networking (which is
-good only for a single-worker deployment; see the documentation of
-[networking plugins](../docs/ansible.md#networking-plugins) for more
-options).  The Swarm master is modified for multi-tenant use.
+has a Kubernetes cluster.  The networking is done by Flannel using its
+`host-gw` "backend" (which uses ordinary IP routing and connectivity).
 
 Install [git](https://git-scm.com/downloads),
 [Vagrant](https://www.vagrantup.com/) and
@@ -212,6 +209,18 @@ ssh -i ~/.vagrant.d/insecure_private_key vagrant@192.168.10.2
 On the master you will find both the `kubectl` and `docker`
 (currently 1.11) commands on your `$PATH`.
 
+### Exercise Kubernetes
+
+You can create a Kubernetes "deployment" with a command like this:
+```bash
+kubectl run k1 --image=busybox sleep 864000
+```
+
+### Exercise SwarmV1
+
+**NB:** IGNORE THIS SECTION.  It is obsolete, retained here only until
+we find a better place to save it until it becomes relevant again.
+
 The Swarm master is configured for multi-tenant use.  To prepare to
 use it as a tenant, do this on the master:
 ```bash
@@ -246,12 +255,12 @@ configuration from inside, like this:
 docker exec s1 ifconfig
 ```
 
-You can create a Kubernetes "deployment" with a command like this:
-```bash
-kubectl run k1 --image=busybox sleep 864000
-```
+### Exercise Kubernetes and SwarmV1 together
 
-The containers in this deployment will be invisible to Swarm because
+**NB:** IGNORE THIS SECTION.  It is obsolete, retained here only until
+we find a better place to save it until it becomes relevant again.
+
+The containers in Kubernetes will be invisible to Swarm because
 they lack the label identifying your tenant.  To make containers
 visible to Swarm, make a kubernetes pod as follows.  Create a YAML
 file prescribing the pod:


### PR DESCRIPTION
Since we are suspending Swarm support until we find a better
coordination solution than Mesos, the default setting for
`swarm_deploy` is being set to `False`.

Some of the doc changes here also anticipate the factoring out of support for Mesos and Kubernetes as a Mesos framework.  This is only a start on the doc changes.

Also made some general improvements to some comments in `ansible/group_vars/all`.