### PR TITLE
Inventory contract no longer requires unused groups 

### DIFF
--- a/ansible/roles/lb/files/haproxyConfig.j2
+++ b/ansible/roles/lb/files/haproxyConfig.j2
@@ -80,7 +80,7 @@ backend back-rabac-secure
 #############################
 # Swarm
 #############################
-{% if lb_swarm %}
+{% if lb_swarm and swarm_deploy %}
 frontend lb-swarm
 	bind *:{{vip_swarm_master_port}}
 	mode http
@@ -98,7 +98,7 @@ backend swarm_backend
 #############################
 # Mesos
 #############################
-{% if lb_mesos %}
+{% if lb_mesos and mesos_deploy %}
 frontend lb-mesos
 	bind *:{{vip_mesos_master_port}}
 	mode http

--- a/ansible/shard.yml
+++ b/ansible/shard.yml
@@ -50,7 +50,7 @@
   tasks:
   - fail:
       msg: ha_deploy must be True when there are multiple hosts in the mesos_master-{{ cluster_name }} group in your Ansible inventory
-    when: groups['mesos_master-' ~ cluster_name]|length > 1 and not ha_deploy|bool
+    when: mesos_deploy and groups['mesos_master-' ~ cluster_name]|length > 1 and not ha_deploy|bool
 
 - hosts: localhost
   roles:
@@ -91,7 +91,7 @@
   become: yes
   roles:
   - lb
-  - { role: vip, when: "groups['mesos_master-' ~ cluster_name]|length > 1 or ha_deploy|bool" }
+  - { role: vip, when: "mesos_deploy and (groups['mesos_master-' ~ cluster_name]|length > 1 or ha_deploy|bool)" }
 
 - hosts: k8s_auth-{{cluster_name}}
   become: yes

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -128,9 +128,8 @@ and only contain lower case letters, numbers, and the hyphen ('-').
 ### The inventory contract for a shard
 
 The contract for a shard specifies that certain inventory groups
-exist.  All these groups are required, even if their purpose is
-related to a component that is not being deployed.  The groups are as
-follows.
+exist.  The groups are as follows.  A group that is for a component
+not being deployed can be omitted from the inventory.
 
 * `cluster-{{cluster_name}}`: all the machines in the cluster ---
   i.e., the union of the following groups


### PR DESCRIPTION
Revised the inventory contract so that a group that is not used does
not have to be defined in the inventory.